### PR TITLE
Fixes profile rendering empty sections

### DIFF
--- a/client/src/components/AddComponents/BasicInfo.js
+++ b/client/src/components/AddComponents/BasicInfo.js
@@ -26,6 +26,7 @@ export default class BasicInfo extends React.Component {
             className="basic-info"
             type="text"
             value={profileData.company_name}
+            required
           />
 
           <label htmlFor="basic-info">
@@ -37,6 +38,7 @@ export default class BasicInfo extends React.Component {
             className="basic-info"
             type="text"
             value={profileData.website}
+            required
           />
 
           <label htmlFor="basic-info">
@@ -48,6 +50,7 @@ export default class BasicInfo extends React.Component {
             className="basic-info"
             type="text"
             value={profileData.contact_name}
+            required
           />
 
           <label htmlFor="basic-info">
@@ -59,6 +62,7 @@ export default class BasicInfo extends React.Component {
             className="basic-info"
             type="text"
             value={profileData.contact_title}
+            required
           />
 
           <label htmlFor="basic-info">
@@ -70,6 +74,8 @@ export default class BasicInfo extends React.Component {
             className="basic-info"
             type="text"
             value={profileData.contact_email}
+            autoComplete="email"
+            required
           />
 
           <label htmlFor="basic-info">
@@ -82,6 +88,7 @@ export default class BasicInfo extends React.Component {
             type="text"
             value={profileData.description}
             rows="5"
+            required
           />
 
           <label htmlFor="basic-info">

--- a/client/src/components/ProfileComponents/UpdateStatus.js
+++ b/client/src/components/ProfileComponents/UpdateStatus.js
@@ -97,7 +97,6 @@ export default class deleteBtn extends React.Component {
     return (
       <button
         onClick={this.changeStatus}
-        id="home-btn"
         id="change-status-btn"
         style={{ backgroundColor: this.state.color }}
       >

--- a/client/src/utils/filterData.js
+++ b/client/src/utils/filterData.js
@@ -3,7 +3,10 @@ const filter = data => {
   transformed["basic_info"] = data[0][0];
   transformed.answers = {};
   data[1].forEach(element => {
-    if (!transformed.answers[element.category]) {
+    // prevents empty category sections from being rendered
+    if (element.answer.length === 0 || element.answer[0] === "no") {
+      console.log("no links here!!");
+    } else if (!transformed.answers[element.category]) {
       // create category
       transformed.answers[element.category] = [];
       transformed.answers[element.category].push(element);


### PR DESCRIPTION
Relates #134 
- stops link section from rendering despite link answer array being empty
- stops empty sections being rendered because the answer to a checkbox is "no"

- also makes most basic info inputs on the edit-profile-page required